### PR TITLE
Replace pg_authid with its more public version pg_roles

### DIFF
--- a/pg_export/templates/base/in/server.sql
+++ b/pg_export/templates/base/in/server.sql
@@ -16,7 +16,7 @@ select quote_ident(s.srvname) as name,
        (select coalesce(
                  json_agg(
                    json_build_object(
-                     'role', quote_ident(a.rolname),
+                     'role', quote_ident(r.rolname),
                      'options', (select coalesce(
                                           json_agg(
                                             json_build_object(
@@ -25,11 +25,11 @@ select quote_ident(s.srvname) as name,
                                           '[]')
                                    from unnest(m.umoptions) u(str)
                                   cross join split_part(u.str, '=', 1) sp(name)
-                                  cross join substr(u.str, length(sp.name) + 2) ss(value))) order by a.rolname nulls last),
+                                  cross join substr(u.str, length(sp.name) + 2) ss(value))) order by r.rolname nulls last),
                  '[]')
           from pg_user_mappings m
-          left join pg_authid a
-                 on a.oid = m.umuser
+          left join pg_roles r
+                 on r.oid = m.umuser
          where m.srvid = s.oid) as user_mappings
   from pg_foreign_server s
   {% with objid='s.oid', objclass='pg_foreign_server' -%} {% include 'in/_join_description_as_d.sql' %} {% endwith %}


### PR DESCRIPTION
Replace pg_authid with its more public version pg_roles to allow run pg_export with less privileges.