### PR TITLE
Add MAINTAIN privilege support which was introduced in Postgresql 17 beta 1

### DIFF
--- a/pg_export/acl.py
+++ b/pg_export/acl.py
@@ -12,7 +12,8 @@ acl_map = {
     'U': 'usage',
     'C': 'create',
     'T': 'temp',
-    'c': 'connect'
+    'c': 'connect',
+    'm': 'maintain'
 }
 
 acl_order = 'rawdDxtXUCTc'


### PR DESCRIPTION
Add MAINTAIN privilege support which was introduced in Postgresql 17 beta 1

This fix adds MAINTAIN privilege support. For details about this privilege, see:

https://github.com/postgres/postgres/commit/ecb0fd33720fab91df1207e85704f382f55e1eb7

This will update exported data for all tables if you upgraded your PostgreSQL cluster version to 17 or higher. Thus, instead of:

grant select, insert, update, delete, truncate, references, trigger on table `table` to `grantee`

it will look:

grant maintain, select, insert, update, delete, truncate, references, trigger on table `table` to `grantee`